### PR TITLE
:bug: imported illumina report multi breeds file have the same FID in output

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -22,6 +22,11 @@ TODO
   both in *import_samples* and *import_metadata* scripts
 * define a collection for all available *purpose* phenotypes
 
+0.4.3.dev0
+----------
+
+* Bug fixed in importing multibreed reportfile (setting FID properly in output)
+
 0.4.2 (2021-08-27)
 ------------------
 

--- a/src/features/plinkio.py
+++ b/src/features/plinkio.py
@@ -885,12 +885,15 @@ class IlluminaReportIO(SmarterMixin):
                         dataset=dataset
                     )
 
-                    fid = sample.breed_code
-                    logger.debug(f"Found breed {fid} from {row.sample_id}")
+                    breed = sample.breed_code
+                    logger.debug(f"Found breed {breed} from {row.sample_id}")
+
+                else:
+                    breed = fid
 
                 # set values. I need to set a breed code in order to get a
                 # proper ped line
-                line[0], line[1], line[5] = fid, row.sample_id, -9
+                line[0], line[1], line[5] = breed, row.sample_id, -9
 
                 # track last sample
                 last_sample = row.sample_id

--- a/tests/data/test_import_from_illumina.py
+++ b/tests/data/test_import_from_illumina.py
@@ -15,7 +15,7 @@ from unittest.mock import patch, PropertyMock
 from plinkio import plinkfile
 
 from src.data.import_from_illumina import main as import_from_illumina
-from src.features.smarterdb import SampleSheep, Dataset
+from src.features.smarterdb import SampleSheep, Dataset, Breed
 
 from ..common import (
     MongoMockMixin, SmarterIDMixin, VariantsMixin, SupportedChipMixin)
@@ -26,6 +26,18 @@ DATA_DIR = pathlib.Path(__file__).parents[1] / "features/data"
 class TestImportFromIllumina(
         VariantsMixin, SmarterIDMixin, SupportedChipMixin, MongoMockMixin,
         unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        breed = Breed(
+            species="Sheep",
+            name="Merino",
+            code="MER",
+            n_individuals=0,
+        )
+        breed.save()
 
     @classmethod
     def tearDownClass(cls):
@@ -112,17 +124,27 @@ class TestImportFromIllumina(
         """Search breed relying on database"""
 
         # create two fake samples to colled fid relying on database
-        for i in range(2):
-            sample = SampleSheep(
-                original_id=f"{i+1}",
-                country="Italy",
-                breed="Texel",
-                breed_code="TEX",
-                species="Sheep",
-                dataset=self.dataset,
-                chip_name=self.chip_name
-            )
-            sample.save()
+        sample = SampleSheep(
+            original_id="1",
+            country="Italy",
+            breed="Texel",
+            breed_code="TEX",
+            species="Sheep",
+            dataset=self.dataset,
+            chip_name=self.chip_name
+        )
+        sample.save()
+
+        sample = SampleSheep(
+            original_id="2",
+            country="Italy",
+            breed="Merino",
+            breed_code="MER",
+            species="Sheep",
+            dataset=self.dataset,
+            chip_name=self.chip_name
+        )
+        sample.save()
 
         # create a temporary directory using the context manager
         with tempfile.TemporaryDirectory() as tmpdirname:
@@ -168,6 +190,11 @@ class TestImportFromIllumina(
 
             self.assertEqual(len(sample_list), 2)
             self.assertEqual(len(locus_list), 2)
+
+            # assert two different FID for samples
+            for record in sample_list:
+                sample = SampleSheep.objects.get(smarter_id=record.iid)
+                self.assertEqual(sample.breed_code, record.fid)
 
     @patch('src.features.plinkio.SmarterMixin.fetch_coordinates')
     @patch('src.features.smarterdb.Dataset.result_dir',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR solve a bug fixes described in #32 (multi breeds illumina report need to solve the proper FID

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Put closes #XXXX in your comment to auto-close the issue that your -->
<!--- PR fixes (if such).Please link to the issue here: -->
closes #32 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR solve a bug an give to imported reportfile the correct FID relying on database

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Code has been tested with unitest and dataset was generated to ensure samples have the proper FID

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change which improve code itself)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
