### PR TITLE
:sparkles: track constants and status in database

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,7 +25,8 @@ TODO
 0.4.3.dev0
 ----------
 
-* add *foreground/background* type attribute in ``SampleSpecies``
+* Track database status and constants
+* Add *foreground/background* type attribute in ``SampleSpecies``
 * Update dependencies
 * Add make rule to pack results and make checksum
 * Move greek foreground metadata to a custom phenotypes dataset

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -21,11 +21,11 @@ TODO
 * if ``src_dataset`` and ``dst_dataset`` are equals, provide only ``dst_dataset``
   both in *import_samples* and *import_metadata* scripts
 * define a collection for all available *purpose* phenotypes
-* add *foreground/background* type attribute in ``SampleSpecies``
 
 0.4.3.dev0
 ----------
 
+* add *foreground/background* type attribute in ``SampleSpecies``
 * Update dependencies
 * Add make rule to pack results and make checksum
 * Move greek foreground metadata to a custom phenotypes dataset

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ data: requirements
 	$(PYTHON_INTERPRETER) src/data/import_from_plink.py --bfile ADAPTmap_genotypeTOP_20161201/binary_fileset/ADAPTmap_genotypeTOP_20161201 \
 		--dataset "ADAPTmap_genotypeTOP_20161201.zip" --chip_name IlluminaGoatSNP50 --assembly ARS1
 	$(PYTHON_INTERPRETER) src/data/import_from_illumina.py --report AUTH_GOAT53KV1_EGHORIA_SKOPELOS/Aristotle_University_GOAT53KV1_20200728_FinalReport.txt \
-	 	--snpfile AUTH_GOAT53KV1_EGHORIA_SKOPELOS/SNP_Map.txt --dataset AUTH_GOAT53KV1_EGHORIA_SKOPELOS.zip \
+		--snpfile AUTH_GOAT53KV1_EGHORIA_SKOPELOS/SNP_Map.txt --dataset AUTH_GOAT53KV1_EGHORIA_SKOPELOS.zip \
 		--chip_name IlluminaGoatSNP50 --assembly ARS1
 
 	## add additional metadata to samples
@@ -269,6 +269,10 @@ data: requirements
 	## merge SNPs into 1 file
 	$(PYTHON_INTERPRETER) src/data/merge_datasets.py --species sheep --assembly OAR3
 	$(PYTHON_INTERPRETER) src/data/merge_datasets.py --species goat --assembly ARS1
+
+	## track database status
+	$(PYTHON_INTERPRETER) src/data/update_db_status.py
+
 
 ## pack results to be shared via sFTP
 publish:

--- a/src/data/import_samples.py
+++ b/src/data/import_samples.py
@@ -24,7 +24,7 @@ import pycountry
 from src.data.common import (
     fetch_and_check_dataset, pandas_open, get_sample_species)
 from src.features.smarterdb import (
-    global_connection, Breed, get_or_create_sample, SEX)
+    global_connection, Breed, get_or_create_sample, SEX, get_sample_type)
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +119,9 @@ def main(
     # mind dataset species
     SampleSpecie = get_sample_species(dst_dataset.species)
 
+    # get sample type
+    type_ = get_sample_type(dst_dataset)
+
     # read datafile
     data = pandas_open(datapath)
 
@@ -187,6 +190,7 @@ def main(
             SampleSpecie,
             original_id,
             dst_dataset,
+            type_,
             breed,
             country.name,
             chip_name,

--- a/src/data/update_db_status.py
+++ b/src/data/update_db_status.py
@@ -51,7 +51,7 @@ def main():
 
 if __name__ == '__main__':
     log_fmt = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-    logging.basicConfig(level=logging.DEBUG, format=log_fmt)
+    logging.basicConfig(level=logging.INFO, format=log_fmt)
 
     # connect to database
     global_connection()

--- a/src/data/update_db_status.py
+++ b/src/data/update_db_status.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Nov 10 18:18:26 2021
+
+@author: Paolo Cozzi <paolo.cozzi@ibba.cnr.it>
+"""
+
+import click
+import logging
+import datetime
+
+from pathlib import Path
+
+from mongoengine.errors import DoesNotExist
+
+from src import __version__
+from src.data.common import WORKING_ASSEMBLIES, PLINK_SPECIES_OPT
+from src.features.smarterdb import (
+    global_connection, SmarterInfo)
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+def main():
+    """Update SMARTER database statuses"""
+
+    logger.info(f"{Path(__file__).name} started")
+
+    try:
+        database = SmarterInfo.objects.get(id="smarter")
+        logger.debug(f"Found: {database}")
+
+    except DoesNotExist:
+        logger.warning("Smarter database status was never tracked")
+        database = SmarterInfo(id="smarter")
+
+    # update stuff
+    database.version = __version__
+    database.working_assemblies = WORKING_ASSEMBLIES
+    database.plink_specie_opt = PLINK_SPECIES_OPT
+    database.last_updated = datetime.datetime.now()
+
+    database.save()
+
+    logger.info("Database status updated")
+
+    logger.info(f"{Path(__file__).name} ended")
+
+
+if __name__ == '__main__':
+    log_fmt = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    logging.basicConfig(level=logging.DEBUG, format=log_fmt)
+
+    # connect to database
+    global_connection()
+
+    main()

--- a/src/features/plinkio.py
+++ b/src/features/plinkio.py
@@ -23,7 +23,7 @@ from plinkio import plinkfile
 from .snpchimp import clean_chrom
 from .smarterdb import (
     VariantSheep, SampleSheep, Breed, Dataset, SmarterDBException, SEX,
-    VariantGoat, SampleGoat, Location)
+    VariantGoat, SampleGoat, Location, get_sample_type)
 from .utils import TqdmToLogger
 from .illumina import read_snpList, read_illuminaRow
 
@@ -250,6 +250,9 @@ class SmarterMixin():
             # do I have a multi country dataset?
             country = self.get_country(dataset, breed)
 
+            # test if foreground or background dataset
+            type_ = get_sample_type(dataset)
+
             # insert sample into database
             logger.info(f"Registering sample '{line[1]}' in database")
             sample = self.SampleSpecies(
@@ -259,6 +262,7 @@ class SmarterMixin():
                 breed=breed.name,
                 breed_code=breed.code,
                 dataset=dataset,
+                type_=type_,
                 chip_name=self.chip_name,
                 sex=sex,
                 father_id=father_id,

--- a/src/features/smarterdb.py
+++ b/src/features/smarterdb.py
@@ -369,6 +369,11 @@ class Phenotype(mongoengine.DynamicEmbeddedDocument):
         return f"{self.to_json()}"
 
 
+class SAMPLETYPE(Enum):
+    FOREGROUND = 'foreground'
+    BACKGROUND = 'background'
+
+
 class SampleSpecies(mongoengine.Document):
     original_id = mongoengine.StringField(required=True)
     smarter_id = mongoengine.StringField(required=True, unique=True)
@@ -388,6 +393,9 @@ class SampleSpecies(mongoengine.Document):
         db_field="dataset_id",
         reverse_delete_rule=mongoengine.DENY
     )
+
+    # add type tag
+    type_ = mongoengine.EnumField(SAMPLETYPE, db_field="type", required=True)
 
     # track the original chip_name with sample
     chip_name = mongoengine.StringField()
@@ -479,6 +487,7 @@ def get_or_create_sample(
         SampleSpecies: Union[SampleGoat, SampleSheep],
         original_id: str,
         dataset: Dataset,
+        type_: str,
         breed: Breed,
         country: str,
         chip_name: str = None,
@@ -492,6 +501,7 @@ def get_or_create_sample(
             for insert/update
         original_id (str): The original_id in the dataset
         dataset (Dataset): the dataset instance used to register sample
+        type_ (str): "background" or "foreground"
         breed (Breed): A breed instance
         country (str): Country as a string
         chip_name (str): the chip name
@@ -522,6 +532,7 @@ def get_or_create_sample(
             breed=breed.name,
             breed_code=breed.code,
             dataset=dataset,
+            type_=type_,
             chip_name=chip_name,
             sex=sex,
             alias=alias

--- a/src/features/smarterdb.py
+++ b/src/features/smarterdb.py
@@ -67,6 +67,24 @@ def complement(genotype: str):
     return result
 
 
+class SmarterInfo(mongoengine.Document):
+    """A class to track database status informations"""
+
+    id = mongoengine.StringField(primary_key=True)
+    version = mongoengine.StringField(required=True)
+    working_assemblies = mongoengine.DictField()
+    plink_specie_opt = mongoengine.DictField()
+    last_updated = mongoengine.DateTimeField()
+
+    meta = {
+        'db_alias': DB_ALIAS,
+        'collection': 'smarterInfo'
+    }
+
+    def __str__(self):
+        return f"{self.id}: {self.version}"
+
+
 class Counter(mongoengine.Document):
     """A class to deal with counter collection (created when initializing
     smarter database)

--- a/src/features/smarterdb.py
+++ b/src/features/smarterdb.py
@@ -552,6 +552,29 @@ def get_or_create_sample(
     return sample, created
 
 
+def get_sample_type(dataset: Dataset):
+    """
+    test if foreground or background dataset
+
+    Args:
+        dataset (Dataset): the dataset instance used to register sample
+
+    Returns:
+        str: sample type ("background" or "foreground")
+    """
+
+    type_ = None
+
+    for sampletype in SAMPLETYPE:
+        if sampletype.value in dataset.type_:
+            logger.warning(
+                f"Found {sampletype.value} in {dataset.type_}")
+            type_ = sampletype.value
+            break
+
+    return type_
+
+
 class Consequence(mongoengine.EmbeddedDocument):
     pass
 

--- a/src/features/smarterdb.py
+++ b/src/features/smarterdb.py
@@ -585,7 +585,7 @@ def get_sample_type(dataset: Dataset):
 
     for sampletype in SAMPLETYPE:
         if sampletype.value in dataset.type_:
-            logger.warning(
+            logger.debug(
                 f"Found {sampletype.value} in {dataset.type_}")
             type_ = sampletype.value
             break

--- a/tests/common.py
+++ b/tests/common.py
@@ -61,7 +61,8 @@ class SmarterIDMixin():
                 "finalreport.txt",
                 "affytest.map",
                 "affytest.ped"
-            ]
+            ],
+            type_=["background", "genotypes"]
         )
         dataset.save()
 

--- a/tests/data/test_import_from_illumina.py
+++ b/tests/data/test_import_from_illumina.py
@@ -131,6 +131,7 @@ class TestImportFromIllumina(
             breed_code="TEX",
             species="Sheep",
             dataset=self.dataset,
+            type_="background",
             chip_name=self.chip_name
         )
         sample.save()
@@ -142,6 +143,7 @@ class TestImportFromIllumina(
             breed_code="MER",
             species="Sheep",
             dataset=self.dataset,
+            type_="background",
             chip_name=self.chip_name
         )
         sample.save()

--- a/tests/data/test_import_metadata.py
+++ b/tests/data/test_import_metadata.py
@@ -91,6 +91,7 @@ class MetaDataMixin(SmarterIDMixin, SupportedChipMixin, MongoMockMixin):
             breed="Texel",
             breed_code="TEX",
             dataset=self.dst_dataset,
+            type_="background",
             chip_name=self.chip_name,
         )
         self.sample1.save()
@@ -103,6 +104,7 @@ class MetaDataMixin(SmarterIDMixin, SupportedChipMixin, MongoMockMixin):
             breed="Merino",
             breed_code="MER",
             dataset=self.dst_dataset,
+            type_="background",
             chip_name=self.chip_name,
         )
         self.sample2.save()

--- a/tests/data/test_import_phenotypes.py
+++ b/tests/data/test_import_phenotypes.py
@@ -88,6 +88,7 @@ class PhenotypeMixin(SmarterIDMixin, SupportedChipMixin, MongoMockMixin):
             breed="Texel",
             breed_code="TEX",
             dataset=self.dst_dataset,
+            type_="background",
             chip_name=self.chip_name,
             alias="alias-1",
         )

--- a/tests/data/test_import_samples.py
+++ b/tests/data/test_import_samples.py
@@ -37,7 +37,8 @@ class TestImportSamples(
             species="Sheep",
             contents=[
                 "metadata.xlsx"
-            ]
+            ],
+            type_=["background", "genotypes"]
         )
         cls.src_dataset.save()
 
@@ -77,6 +78,7 @@ class TestImportSamples(
             breed="Texel",
             breed_code="TEX",
             dataset=self.dst_dataset,
+            type_="background",
             chip_name=self.chip_name,
         )
         self.sample.save()

--- a/tests/data/test_update_db_status.py
+++ b/tests/data/test_update_db_status.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Nov 10 18:19:06 2021
+
+@author: Paolo Cozzi <paolo.cozzi@ibba.cnr.it>
+"""
+
+import json
+import unittest
+
+from click.testing import CliRunner
+
+from src import __version__
+from src.features.smarterdb import SmarterInfo
+from src.data.common import WORKING_ASSEMBLIES, PLINK_SPECIES_OPT
+from src.data.update_db_status import main as update_db_status
+
+from ..common import MongoMockMixin
+
+
+class UpdateDBStatusTest(MongoMockMixin, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.working_assemblies = json.loads(json.dumps(WORKING_ASSEMBLIES))
+        self.plink_specie_opt = json.loads(json.dumps(PLINK_SPECIES_OPT))
+
+        self.runner = CliRunner()
+
+    def test_help(self):
+        result = self.runner.invoke(update_db_status, ["--help"])
+        self.assertEqual(0, result.exit_code)
+        self.assertIn('Usage: main', result.output)
+
+    def test_create_status(self):
+        result = self.runner.invoke(update_db_status, [])
+
+        self.assertEqual(0, result.exit_code)
+
+        qs = SmarterInfo.objects()
+        self.assertEqual(qs.count(), 1)
+
+        info = qs.get()
+        self.assertEqual(info.version, __version__)
+        self.assertDictEqual(info.working_assemblies, self.working_assemblies)
+        self.assertDictEqual(info.plink_specie_opt, self.plink_specie_opt)
+
+    def test_update_status(self):
+        # create an initial object
+        info = SmarterInfo(id="smarter", version="old")
+        info.save()
+
+        result = self.runner.invoke(update_db_status, [])
+
+        self.assertEqual(0, result.exit_code)
+
+        qs = SmarterInfo.objects()
+        self.assertEqual(qs.count(), 1)
+
+        info = qs.get()
+        self.assertEqual(info.version, __version__)
+        self.assertDictEqual(info.working_assemblies, self.working_assemblies)
+        self.assertDictEqual(info.plink_specie_opt, self.plink_specie_opt)

--- a/tests/features/test_plinkio.py
+++ b/tests/features/test_plinkio.py
@@ -688,6 +688,7 @@ class IlluminaReportIOPed(
                 breed_code="TEX",
                 species="Sheep",
                 dataset=self.dataset,
+                type_="background",
                 chip_name=self.chip_name
             )
             sample.save()

--- a/tests/features/test_smarterdb.py
+++ b/tests/features/test_smarterdb.py
@@ -14,7 +14,7 @@ from unittest.mock import patch
 from src.features.smarterdb import (
     VariantSheep, Location, SampleSheep,
     SmarterDBException, getSmarterId, Breed, get_or_create_breed, Dataset,
-    BreedAlias, get_or_create_sample, SEX)
+    BreedAlias, get_or_create_sample, SEX, get_sample_type)
 
 from ..common import MongoMockMixin, SmarterIDMixin
 
@@ -583,6 +583,12 @@ class SampleSheepTestCase(SmarterIDMixin, MongoMockMixin, unittest.TestCase):
         self.assertEqual(sample.smarter_id, self.smarter_id)
         self.assertEqual(SampleSheep.objects.count(), 1)
         self.assertFalse(created)
+
+    def test_get_sample_type(self):
+        self.create_sample()
+
+        test = get_sample_type(self.dataset)
+        self.assertEqual("background", test)
 
 
 class SEXTestCase(unittest.TestCase):

--- a/tests/features/test_smarterdb.py
+++ b/tests/features/test_smarterdb.py
@@ -508,6 +508,7 @@ class SampleSheepTestCase(SmarterIDMixin, MongoMockMixin, unittest.TestCase):
         self.chip_name = "IlluminaOvineSNP50"
         self.sex = SEX.MALE
         self.alias = "TEST-ALIAS"
+        self.type_ = "background"
 
     def tearDown(self):
         SampleSheep.objects().delete()
@@ -519,7 +520,8 @@ class SampleSheepTestCase(SmarterIDMixin, MongoMockMixin, unittest.TestCase):
 
         self.sample = SampleSheep(
             original_id=self.original_id,
-            smarter_id=None
+            smarter_id=None,
+            type_="background"
         )
 
         # need country, breed and species in order to get a smarter_id
@@ -551,6 +553,7 @@ class SampleSheepTestCase(SmarterIDMixin, MongoMockMixin, unittest.TestCase):
             SampleSheep,
             self.original_id,
             self.dataset,
+            self.type_,
             self.breed,
             self.country,
             self.chip_name,
@@ -568,6 +571,7 @@ class SampleSheepTestCase(SmarterIDMixin, MongoMockMixin, unittest.TestCase):
             SampleSheep,
             self.original_id,
             self.dataset,
+            self.type_,
             self.breed,
             self.country,
             self.chip_name,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With this PR we track database constants in a collection and we add *background*/*foreground* types to the samples

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Put closes #XXXX in your comment to auto-close the issue that your -->
<!--- PR fixes (if such).Please link to the issue here: -->
closes #11

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required to track information that can useful in API

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
code as been tested with CI and by recreating the database

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change which improve code itself)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
