### PR TITLE
:boom: model location with MultiPointField

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,6 +25,7 @@ TODO
 0.4.4.dev0
 ----------
 
+* Model location with MultiPointField
 * Describe smarter metadata
 * Import sweden goat metadata
 * Import latest 290 samples greek dataset

--- a/src/features/smarterdb.py
+++ b/src/features/smarterdb.py
@@ -434,6 +434,9 @@ class SampleSpecies(mongoengine.Document):
 
     meta = {
         'abstract': True,
+        'indexes': [
+            [("locations", "2dsphere")]
+        ]
     }
 
     def save(self, *args, **kwargs):

--- a/src/features/smarterdb.py
+++ b/src/features/smarterdb.py
@@ -423,7 +423,8 @@ class SampleSpecies(mongoengine.Document):
 
     # GPS location
     # NOTE: X, Y where X is longitude, Y latitude
-    locations = mongoengine.ListField(mongoengine.PointField(), default=None)
+    locations = mongoengine.fields.MultiPointField(
+        auto_index=True, default=None)
 
     # additional (not modelled) metadata
     metadata = mongoengine.DictField(default=None)

--- a/tests/data/test_import_metadata.py
+++ b/tests/data/test_import_metadata.py
@@ -116,30 +116,23 @@ class MetaDataMixin(SmarterIDMixin, SupportedChipMixin, MongoMockMixin):
 
     def check_sample1_locations(self):
         self.sample1.reload()
-        self.assertListEqual(
+        self.assertEqual(
             self.sample1.locations,
-            [
-                {
-                    'type': 'Point',
-                    'coordinates': [9.18951, 45.46427]
-                }
-            ]
+            {
+                'type': 'MultiPoint',
+                'coordinates': [[9.18951, 45.46427]]
+            }
+        
         )
 
     def check_sample2_locations(self):
         self.sample2.reload()
-        self.assertListEqual(
+        self.assertEqual(
             self.sample2.locations,
-            [
-                {
-                    'type': 'Point',
-                    'coordinates': [9.18951, 45.46427]
-                },
-                {
-                    'type': 'Point',
-                    'coordinates': [10.18951, 46.46427]
-                },
-            ]
+            {
+                'type': 'MultiPoint', 
+                'coordinates': [[9.18951, 45.46427], [10.18951, 46.46427]]
+            }
         )
 
     def check_sample1_metadata(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In this PR we try to module locations with with [MultiPointField](http://docs.mongoengine.org/apireference.html#mongoengine.fields.MultiPointField)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Put closes #XXXX in your comment to auto-close the issue that your -->
<!--- PR fixes (if such).Please link to the issue here: -->
closes #41 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR will set up *spatial indexes* properly and let use mongoengine methods to perform *spatial queries*

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Code has been tested with `unittest` and by importing metadata

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change which improve code itself)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
