### PR TITLE
:sparkles: add multiple phenotypes to samples

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,6 +18,8 @@ TODO
 0.4.8.post1
 -----------
 
+* Load multiple phenotypes for *Boutsko foreground* sheeps
+* Add multiple phenotypes as a list (`103 <https://github.com/cnr-ibba/SMARTER-database/issues/103>`__)
 * Update *datasets* metadata
 
 0.4.8 (2023-06-28)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,11 @@ TODO
 * Manage python packages with `poetry <https://python-poetry.org/>`__
 * Rename ``manifacturer`` into ``manufacturer``
 
+0.4.8.post1
+-----------
+
+* Update *datasets* metadata
+
 0.4.8 (2023-06-28)
 ------------------
 

--- a/Makefile
+++ b/Makefile
@@ -670,6 +670,18 @@ data: requirements
 		--datafile doi_10.5061_dryad.q1cv6__v1/burren_phenotypes_fix.xlsx --breed_column breed \
 		--additional_column coat_color --additional_column hair --additional_column horns \
 		--additional_column size_male --additional_column size_female --additional_column performance
+	$(PYTHON_INTERPRETER) src/data/import_multiple_phenotypes.py \
+		--src_dataset "Smarter - Grazing behaviour phenotypes - Boutsko sheep.zip" \
+		--dst_dataset AUTH_OVN50KV2_CHIOS_MYTILINI_BOUTSKO.zip \
+		--datafile "Smarter - Grazing behaviour phenotypes - Boutsko sheep.xlsx" --id_column id \
+		--column daily_activity_min --column daily_distance_km --column mean_speed_moving_m \
+		--column altitude_difference_m --column elevation_gain_m --column energy_expenditure_MJ
+	$(PYTHON_INTERPRETER) src/data/import_multiple_phenotypes.py \
+		--src_dataset "Smarter - Grazing behaviour phenotypes - Boutsko sheep.zip" \
+		--dst_dataset AUTH_OVN50KV2_CHI_BOU_MYT_FRI.zip \
+		--datafile "Smarter - Grazing behaviour phenotypes - Boutsko sheep.xlsx" --id_column id \
+		--column daily_activity_min --column daily_distance_km --column mean_speed_moving_m \
+		--column altitude_difference_m --column elevation_gain_m --column energy_expenditure_MJ
 
 	## merge SNPs into 1 file
 	$(foreach ASSEMBLY, $(SHEEP_ASSEMBLIES), $(PYTHON_INTERPRETER) src/data/merge_datasets.py --species_class sheep --assembly $(ASSEMBLY);)

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -80,6 +80,12 @@ documentation sections.
     :prog: src/data/import_metadata.py
     :nested: full
 
+.. _import_multiple_phenotypes:
+
+.. click:: src.data.import_multiple_phenotypes:main
+    :prog: src/data/import_multiple_phenotypes.py
+    :nested: full
+
 .. _import_phenotypes:
 
 .. click:: src.data.import_phenotypes:main

--- a/src/data/import_multiple_phenotypes.py
+++ b/src/data/import_multiple_phenotypes.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Sep 11 12:13:47 2023
+
+@author: Paolo Cozzi <paolo.cozzi@ibba.cnr.it>
+
+This program acts like import_phenotypes but adding more data for the same
+individual
+"""
+
+import click
+import logging
+
+from click_option_group import optgroup, RequiredMutuallyExclusiveOptionGroup
+from pathlib import Path
+
+from src.features.smarterdb import global_connection
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.option(
+    '--src_dataset', type=str, required=True,
+    help="The raw dataset file name (zip archive) in which search datafile"
+)
+@click.option(
+    '--dst_dataset', type=str, required=False,
+    help=("The raw dataset file name (zip archive) in which add metadata"
+          "(def. the 'src_dataset')")
+)
+@click.option('--datafile', type=str, required=True)
+@click.option('--sheet_name',
+              default="0",
+              help="pandas 'sheet_name' option")
+@optgroup.group(
+    'Add metadata relying on breeds or samples columns',
+    cls=RequiredMutuallyExclusiveOptionGroup
+)
+@optgroup.option('--breed_column', type=str, help="The breed column")
+@optgroup.option('--id_column', type=str, help="The original_id column")
+@optgroup.option('--alias_column', type=str, help="An alias for original_id")
+@click.option(
+    '--column',
+    required=True,
+    multiple=True,
+    help=(
+        "Column to track. Could be specified multiple times")
+)
+@click.option('--na_values', type=str, help="pandas NA values")
+def main(src_dataset, dst_dataset, datafile, sheet_name, breed_column,
+         id_column, alias_column, column, na_values):
+    """Read multiple data for the same sample from phenotype file and add it
+    to SMARTER-database samples"""
+
+    logger.info(f"{Path(__file__).name} started")
+
+    if breed_column or alias_column:
+        raise NotImplementedError(
+            "Loading multiple phenotypes by breed or alias is not yet "
+            "implemented")
+
+    logger.debug(f"Reading {column} columns")
+
+    logger.info(f"{Path(__file__).name} ended")
+
+
+if __name__ == '__main__':
+    log_fmt = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    logging.basicConfig(level=logging.INFO, format=log_fmt)
+
+    # connect to database
+    global_connection()
+
+    main()

--- a/src/data/import_multiple_phenotypes.py
+++ b/src/data/import_multiple_phenotypes.py
@@ -15,9 +15,32 @@ import logging
 from click_option_group import optgroup, RequiredMutuallyExclusiveOptionGroup
 from pathlib import Path
 
-from src.features.smarterdb import global_connection
+from src.features.smarterdb import global_connection, Phenotype
+from src.data.common import pandas_open, deal_with_datasets, get_sample_species
+from src.features.utils import sanitize
 
 logger = logging.getLogger(__name__)
+
+
+def create_or_update_phenotype(
+        sample, phenotype: dict):
+
+    if not phenotype:
+        logger.debug(f"Skipping {sample}: nothing to update")
+        return
+
+    if not sample.phenotype:
+        logger.debug(f"Create a new phenotype for {sample}")
+        sample.phenotype = Phenotype()
+
+    for key, value in phenotype.items():
+        setattr(sample.phenotype, key, value)
+
+    logger.info(
+        f"Updating '{sample}' phenotype with '{sample.phenotype}'")
+
+    # update sample
+    sample.save()
 
 
 @click.command()
@@ -43,6 +66,7 @@ logger = logging.getLogger(__name__)
 @optgroup.option('--alias_column', type=str, help="An alias for original_id")
 @click.option(
     '--column',
+    'columns',
     required=True,
     multiple=True,
     help=(
@@ -50,7 +74,7 @@ logger = logging.getLogger(__name__)
 )
 @click.option('--na_values', type=str, help="pandas NA values")
 def main(src_dataset, dst_dataset, datafile, sheet_name, breed_column,
-         id_column, alias_column, column, na_values):
+         id_column, alias_column, columns, na_values):
     """Read multiple data for the same sample from phenotype file and add it
     to SMARTER-database samples"""
 
@@ -61,7 +85,35 @@ def main(src_dataset, dst_dataset, datafile, sheet_name, breed_column,
             "Loading multiple phenotypes by breed or alias is not yet "
             "implemented")
 
-    logger.debug(f"Reading {column} columns")
+    logger.debug(f"Reading {columns} columns")
+
+    src_dataset, dst_dataset, datapath = deal_with_datasets(
+        src_dataset, dst_dataset, datafile)
+
+    SampleSpecie = get_sample_species(dst_dataset.species)
+
+    if sheet_name and sheet_name.isnumeric():
+        sheet_name = int(sheet_name)
+
+    # open data with pandas
+    data = pandas_open(datapath, na_values=na_values, sheet_name=sheet_name)
+
+    # process unique ids
+    for id_ in data[id_column].unique():
+        subset = data[data[id_column] == id_]
+
+        phenotype = {}
+
+        for column in columns:
+            phenotype[sanitize(column)] = subset[column].to_list()
+
+        original_id = str(id_)
+
+        # ok iterate over all samples of this dataset
+        for sample in SampleSpecie.objects.filter(
+                dataset=dst_dataset, original_id=original_id):
+
+            create_or_update_phenotype(sample, phenotype)
 
     logger.info(f"{Path(__file__).name} ended")
 

--- a/tests/data/test_import_multiple_phenotypes.py
+++ b/tests/data/test_import_multiple_phenotypes.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Sep 11 12:20:08 2023
+
+@author: Paolo Cozzi <paolo.cozzi@ibba.cnr.it>
+"""
+
+import unittest
+import pathlib
+import tempfile
+
+from openpyxl import Workbook
+from click.testing import CliRunner
+from unittest.mock import patch, PropertyMock
+
+from src.data.import_multiple_phenotypes import (
+    main as import_multiple_phenotypes)
+from src.features.smarterdb import Dataset, SampleSheep, Phenotype
+
+from ..common import MongoMockMixin, SmarterIDMixin, SupportedChipMixin
+
+
+class PhenotypeMixin(SmarterIDMixin, SupportedChipMixin, MongoMockMixin):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # getting destination dataset
+        cls.dst_dataset = Dataset.objects.get(file="test.zip")
+
+        # create a src dataset for genotypes
+        cls.src_dataset = Dataset(
+            file="test2.zip",
+            country="Italy",
+            species="Sheep",
+            contents=[
+                "phenotypes.xlsx"
+            ]
+        )
+        cls.src_dataset.save()
+
+        # create a workbook
+        cls.workbook = Workbook()
+        cls.sheet = cls.workbook.active
+
+        # adding header
+        cls.sheet.cell(row=1, column=1, value="Id")
+        cls.sheet.cell(row=1, column=2, value="daily_activity_min")
+        cls.sheet.cell(row=1, column=3, value="daily_distance_km")
+
+        # adding values
+        cls.sheet.cell(row=2, column=1, value="test-1")
+        cls.sheet.cell(row=2, column=2, value=123)
+        cls.sheet.cell(row=2, column=3, value=11.5)
+        cls.sheet.cell(row=2, column=1, value="test-1")
+        cls.sheet.cell(row=2, column=2, value=456)
+        cls.sheet.cell(row=2, column=3, value=23.0)
+
+    @classmethod
+    def tearDownClass(cls):
+        Dataset.objects.delete()
+        SampleSheep.objects.delete()
+
+        super().tearDownClass()
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+        # need also a sample
+        self.sample = SampleSheep(
+            original_id="test-1",
+            smarter_id="ITOA-TEX-000000001",
+            country="Italy",
+            breed="Texel",
+            breed_code="TEX",
+            dataset=self.dst_dataset,
+            type_="background",
+            chip_name=self.chip_name,
+            alias="alias-1",
+        )
+        self.sample.save()
+
+    def tearDown(self):
+        SampleSheep.objects.delete()
+
+        super().tearDown()
+
+
+class TestImportPhenotypeCLI(PhenotypeMixin, unittest.TestCase):
+    def test_help(self):
+        result = self.runner.invoke(import_multiple_phenotypes, ["--help"])
+        self.assertEqual(0, result.exit_code)
+        self.assertIn('Usage: main', result.output)
+
+
+class TestImportPhenotypeBySamples(PhenotypeMixin, unittest.TestCase):
+    @patch('src.features.smarterdb.Dataset.working_dir',
+           new_callable=PropertyMock)
+    def test_import_phenotype(self, my_working_dir):
+        # create a temporary directory using the context manager
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            working_dir = pathlib.Path(tmpdirname)
+            my_working_dir.return_value = working_dir
+
+            # save worksheet in temporary folder
+            self.workbook.save(f"{working_dir}/phenotypes.xlsx")
+
+            # got first sample from database
+            self.assertEqual(SampleSheep.objects.count(), 1)
+
+            result = self.runner.invoke(
+                import_multiple_phenotypes,
+                [
+                    "--src_dataset",
+                    "test2.zip",
+                    "--dst_dataset",
+                    "test.zip",
+                    "--datafile",
+                    "phenotypes.xlsx",
+                    "--id_column",
+                    "Id",
+                    "--column",
+                    "daily_activity_min",
+                    "--column",
+                    "daily_distance_km",
+                ]
+            )
+
+            self.assertEqual(0, result.exit_code, msg=result.exception)
+            self.sample.reload()
+            self.assertIsInstance(self.sample.phenotype, Phenotype)
+
+            reference = Phenotype(
+                daily_activity_min=[123, 456],
+                daily_distance_km=[11.5, 23.0]
+            )
+
+            self.assertEqual(reference, self.sample.phenotype)

--- a/tests/data/test_import_multiple_phenotypes.py
+++ b/tests/data/test_import_multiple_phenotypes.py
@@ -53,9 +53,12 @@ class PhenotypeMixin(SmarterIDMixin, SupportedChipMixin, MongoMockMixin):
         cls.sheet.cell(row=2, column=1, value="test-1")
         cls.sheet.cell(row=2, column=2, value=123)
         cls.sheet.cell(row=2, column=3, value=11.5)
-        cls.sheet.cell(row=2, column=1, value="test-1")
-        cls.sheet.cell(row=2, column=2, value=456)
-        cls.sheet.cell(row=2, column=3, value=23.0)
+        cls.sheet.cell(row=3, column=1, value="test-1")
+        cls.sheet.cell(row=3, column=2, value=456)
+        cls.sheet.cell(row=3, column=3, value=23.0)
+        cls.sheet.cell(row=4, column=1, value="test-2")
+        cls.sheet.cell(row=4, column=2, value=123)
+        cls.sheet.cell(row=4, column=3, value=11.5)
 
     @classmethod
     def tearDownClass(cls):
@@ -97,7 +100,7 @@ class TestImportPhenotypeCLI(PhenotypeMixin, unittest.TestCase):
 class TestImportPhenotypeBySamples(PhenotypeMixin, unittest.TestCase):
     @patch('src.features.smarterdb.Dataset.working_dir',
            new_callable=PropertyMock)
-    def test_import_phenotype(self, my_working_dir):
+    def test_import_multiple_phenotype(self, my_working_dir):
         # create a temporary directory using the context manager
         with tempfile.TemporaryDirectory() as tmpdirname:
             working_dir = pathlib.Path(tmpdirname)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR will add multiple phenotypes to samples by adding a new `import_multiple_phenotypes.py` script

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Put closes #XXXX in your comment to auto-close the issue that your -->
<!--- PR fixes (if such).Please link to the issue here: -->
closes #103 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR is required to add multiple phenotypes to the same samples 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Changes were tested with CI, by loading multiple phenotypes and then ensuring SMARTER-backend, r-smarter-api and SMARTER-frontend work without problems

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change which improve code itself)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
